### PR TITLE
Add `pyproject.toml` to enable library installation in other projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,31 +5,40 @@
 **running this library with python version 3.8 will result in error** 
 
 ## Installing requirements: 
-- pip install -r requirements.txt
+```shell
+pip install -r requirements.txt
+```
 
-## run sampleAcquis.py example : 
+## run `sampleAcquis.py` example: 
+```shell
 python sampleAcquis.py --ip <ip> --port <port> --device <Tr address> --memory <memory>
                     --bins <number of bins to read> --sqd_bins <number of sqd bins to read>
                     --range 100mV --squared|no-squared
+```
 
-The sampleAcquis.py will acquire data through command socket and save data respectively to 
-analogueData.txt, analogueSqdData.txt, photon.txt and photonSQD.txt  
+The `sampleAcquis.py` will acquire data through command socket and save data respectively to 
+`analogueData.txt`, `analogueSqdData.txt`, `photon.txt` and `photonSQD.txt`
 
 
-## run powermeter_example.py : 
+## run `powermeter_example.py`: 
+```shell
 python3 powermeter_example.py --ip <ip> --port <port>  --acq <num acquis> --channel <channel>
+```
 
-the powermeter_example.py will demonstrate the use of the push acquistion as well as the 
+the `powermeter_example.py` will demonstrate the use of the push acquistion as well as the 
 single trace acquisition. 
 
-## run pmt_example.py : 
+## run `pmt_example.py`: 
+```shell
 python3 pmt_example.py --ip <ip> --port <port> --device <device address> --voltage <voltage>
+```
 
-the pmt_example.py demonstrate how to list all installed pmt, set and read voltage from a selected device
+the `pmt_example.py` demonstrate how to list all installed pmt, set and read voltage from a selected device
 
-## run mpush.py :
+## run `mpush.py`:
+```shell
 python3 mpush.py --ip <ip> --port <port>  --acq <num acquis> --shots <num shots>
                  --acquis_per_file <acquis per file> --log
+```
 
-mpush_example.py demonstrate the use of mpush mode to read multiple datasets from multiple transient recorders, at the same time. 
-
+`mpush_example.py` demonstrate the use of mpush mode to read multiple datasets from multiple transient recorders, at the same time. 

--- a/README.md
+++ b/README.md
@@ -42,3 +42,11 @@ python3 mpush.py --ip <ip> --port <port>  --acq <num acquis> --shots <num shots>
 ```
 
 `mpush_example.py` demonstrate the use of mpush mode to read multiple datasets from multiple transient recorders, at the same time. 
+
+## Install as module:
+#### Execute the following: 
+```shell
+pip install build
+python -m build
+pip install -e .
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,13 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "Licel_TCPIP"
+version = "0.1.0"
+
+[tool.setuptools.dynamic]
+dependencies = {file = "requirements.txt"}
+
+[tool.setuptools.packages.find]
+where = ["."] 


### PR DESCRIPTION
To enable installing the Licel library in other projects a `pyproject.toml` was added to the library.
With that it'll be possible to install the project using the command:
```shell
pip install -e path/to/Licel/library
```